### PR TITLE
Fixed scalar range

### DIFF
--- a/easy3d/renderer/buffers.cpp
+++ b/easy3d/renderer/buffers.cpp
@@ -85,12 +85,16 @@ namespace easy3d {
                     LOG(WARNING) << "model has no valid geometry";
                     return;
                 }
-
-                const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
-                const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                 float min_value = std::numeric_limits<float>::max();
                 float max_value = -std::numeric_limits<float>::max();
-                details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                if(drawable->clamp_range()){
+                    const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
+                    const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
+                    details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                }else{
+                    min_value=drawable->clamp_lower();
+                    max_value=drawable->clamp_upper();
+                }
 
                 auto points = model->get_vertex_property<vec3>("v:point");
                 std::vector<vec2> d_texcoords;

--- a/easy3d/renderer/buffers.cpp
+++ b/easy3d/renderer/buffers.cpp
@@ -87,13 +87,13 @@ namespace easy3d {
                 }
                 float min_value = std::numeric_limits<float>::max();
                 float max_value = -std::numeric_limits<float>::max();
-                if(drawable->clamp_range()){
+                if(!drawable->fixed_scalar_range()){
                     const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
                     const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                     details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
                 }else{
-                    min_value=drawable->clamp_lower();
-                    max_value=drawable->clamp_upper();
+                    min_value=drawable->scalar_range_min();
+                    max_value=drawable->scalar_range_max();
                 }
 
                 auto points = model->get_vertex_property<vec3>("v:point");
@@ -120,11 +120,16 @@ namespace easy3d {
                     return;
                 }
 
-                const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
-                const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                 float min_value = std::numeric_limits<float>::max();
                 float max_value = -std::numeric_limits<float>::max();
-                details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                if(!drawable->fixed_scalar_range()){
+                    const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
+                    const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
+                    details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                }else{
+                    min_value=drawable->scalar_range_min();
+                    max_value=drawable->scalar_range_max();
+                }
 
                 auto points = model->get_vertex_property<vec3>("v:point");
 
@@ -151,11 +156,16 @@ namespace easy3d {
                     return;
                 }
 
-                const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
-                const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                 float min_value = std::numeric_limits<float>::max();
                 float max_value = -std::numeric_limits<float>::max();
-                details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                if(!drawable->fixed_scalar_range()){
+                    const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
+                    const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
+                    details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                }else{
+                    min_value=drawable->scalar_range_min();
+                    max_value=drawable->scalar_range_max();
+                }
 
                 auto points = model->get_vertex_property<vec3>("v:point");
                 std::vector<vec3> d_points;
@@ -189,11 +199,16 @@ namespace easy3d {
                     return;
                 }
 
-                const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
-                const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                 float min_value = std::numeric_limits<float>::max();
                 float max_value = -std::numeric_limits<float>::max();
-                details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                if(!drawable->fixed_scalar_range()){
+                    const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
+                    const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
+                    details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                }else{
+                    min_value=drawable->scalar_range_min();
+                    max_value=drawable->scalar_range_max();
+                }
 
                 auto points = model->get_vertex_property<vec3>("v:point");
                 drawable->update_vertex_buffer(points.vector());
@@ -230,11 +245,16 @@ namespace easy3d {
                     return;
                 }
 
-                const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
-                const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                 float min_value = std::numeric_limits<float>::max();
                 float max_value = -std::numeric_limits<float>::max();
-                details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                if(!drawable->fixed_scalar_range()){
+                    const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
+                    const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
+                    details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                }else{
+                    min_value=drawable->scalar_range_min();
+                    max_value=drawable->scalar_range_max();
+                }
 
                 auto points = model->get_vertex_property<vec3>("v:point");
                 std::vector<vec2> d_texcoords;
@@ -265,11 +285,16 @@ namespace easy3d {
                     model->update_vertex_normals();
                     auto normals = model->get_vertex_property<vec3>("v:normal");
 
-                    const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
-                    const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                     float min_value = std::numeric_limits<float>::max();
                     float max_value = -std::numeric_limits<float>::max();
-                    details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                    if(!drawable->fixed_scalar_range()){
+                        const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
+                        const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
+                        details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                    }else{
+                        min_value=drawable->scalar_range_min();
+                        max_value=drawable->scalar_range_max();
+                    }
 
                     std::vector<vec3> d_points, d_normals;
                     std::vector<vec2> d_texcoords;
@@ -320,11 +345,16 @@ namespace easy3d {
                     model->update_vertex_normals();
                     auto normals = model->get_vertex_property<vec3>("v:normal");
 
-                    const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
-                    const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                     float min_value = std::numeric_limits<float>::max();
                     float max_value = -std::numeric_limits<float>::max();
-                    details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                    if(!drawable->fixed_scalar_range()){
+                        const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
+                        const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
+                        details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                    }else{
+                        min_value=drawable->scalar_range_min();
+                        max_value=drawable->scalar_range_max();
+                    }
 
                     for (auto face : model->faces()) {
                         tessellator.begin_polygon(model->compute_face_normal(face));
@@ -392,11 +422,16 @@ namespace easy3d {
                     model->update_vertex_normals();
                     auto normals = model->get_vertex_property<vec3>("v:normal");
 
-                    const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
-                    const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                     float min_value = std::numeric_limits<float>::max();
                     float max_value = -std::numeric_limits<float>::max();
-                    details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                    if(!drawable->fixed_scalar_range()){
+                        const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
+                        const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
+                        details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                    }else{
+                        min_value=drawable->scalar_range_min();
+                        max_value=drawable->scalar_range_max();
+                    }
 
                     std::vector<vec2> d_texcoords;
                     d_texcoords.reserve(model->n_vertices());
@@ -445,11 +480,16 @@ namespace easy3d {
                     model->update_vertex_normals();
                     auto normals = model->get_vertex_property<vec3>("v:normal");
 
-                    const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
-                    const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                     float min_value = std::numeric_limits<float>::max();
                     float max_value = -std::numeric_limits<float>::max();
-                    details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                    if(!drawable->fixed_scalar_range()){
+                        const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
+                        const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
+                        details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                    }else{
+                        min_value=drawable->scalar_range_min();
+                        max_value=drawable->scalar_range_max();
+                    }
 
                     for (auto face : model->faces()) {
                         tessellator.begin_polygon(model->compute_face_normal(face));
@@ -511,11 +551,16 @@ namespace easy3d {
                     return;
                 }
 
-                const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
-                const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                 float min_value = std::numeric_limits<float>::max();
                 float max_value = -std::numeric_limits<float>::max();
-                details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                if(!drawable->fixed_scalar_range()){
+                    const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
+                    const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
+                    details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                }else{
+                    min_value=drawable->scalar_range_min();
+                    max_value=drawable->scalar_range_max();
+                }
 
                 auto points = model->get_vertex_property<vec3>("v:point");
                 std::vector<vec3> d_points;
@@ -550,11 +595,16 @@ namespace easy3d {
                     return;
                 }
 
-                const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
-                const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
                 float min_value = std::numeric_limits<float>::max();
                 float max_value = -std::numeric_limits<float>::max();
-                details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                if(!drawable->fixed_scalar_range()){
+                    const float dummy_lower = (drawable->clamp_range() ? drawable->clamp_lower() : 0.0f);
+                    const float dummy_upper = (drawable->clamp_range() ? drawable->clamp_upper() : 0.0f);
+                    details::clamp_scalar_field(prop.vector(), min_value, max_value, dummy_lower, dummy_upper);
+                }else{
+                    min_value=drawable->scalar_range_min();
+                    max_value=drawable->scalar_range_max();
+                }
 
                 auto points = model->get_vertex_property<vec3>("v:point");
                 drawable->update_vertex_buffer(points.vector());

--- a/easy3d/renderer/state.h
+++ b/easy3d/renderer/state.h
@@ -178,6 +178,17 @@ namespace easy3d {
         float texture_fractional_repeat() const { return texture_fractional_repeat_; };
         void set_texture_fractional_repeat(float fr) { texture_fractional_repeat_ = fr; };
 
+        /** fix the value range of a scalar field. */
+        bool fixed_scalar_range() const { return fixed_scalar_range_; }
+        void set_fixed_scalar_range(bool b) { fixed_scalar_range_ = b; }
+
+        /** the lower side of the value range of a scalar field. */
+        float scalar_range_min() const { return scalar_min_; }
+        void set_scalar_range(float low, float high) { scalar_min_ = low; scalar_max_=high; }
+
+        /** Clamp the upper side of the value range of a scalar field. */
+        float scalar_range_max() const { return scalar_max_; }
+
         /** Clamp the value range of a scalar field. */
         bool clamp_range() const { return clamp_range_; }
         void set_clamp_range(bool b) { clamp_range_ = b; }
@@ -233,6 +244,10 @@ namespace easy3d {
         bool clamp_range_;
         float clamp_lower_;
         float clamp_upper_;
+
+        bool fixed_scalar_range_=false;
+        float scalar_min_;
+        float scalar_max_;
 
         Material material_;
 


### PR DESCRIPTION
## 問題

Scalarを使って色をつけるとき、Scalarを色テーブルのテクスチャ座標に変換する必要がある。これはupdate時にScalarをstd::sortすることで最大値と最小値を探し([buffers.cpp](https://github.com/kiyoshiiriemon/Easy3D/blob/0d03522b79db665c08a5df9b29f77a538144e6ea/easy3d/renderer/buffers.cpp#L60) )、これを適当にclampし(clamp_upper/clamp_lower)て実現していた。この方法は以下の問題がある。

1. std::sortが重い。Intensityなど決め打ちでいいはず。
2. 決定したマッピングを取得する方法がたぶんない。すなわち色とScalarの対応付けがわからない。

## 解決手段

State に新たに fixed_scalar, scalar_min, scalar_max を導入し、buffers::update オーバーロード群でこれらを使って範囲を固定できるように修正。何もしなければ従来の挙動と変わらず、固定したければ例えば以下のようにする。
``` c++
  // Model *model;            // スカラを持ったPointCloud等のモデル。Rendererを追加済みと仮定
  // Texture *LUTTexture;   // スカラを色に対応づける適当なテクスチャ
  auto drawable=model->renderer()->get_points_drawable();
  drawable->state().set_scalar_coloring(State::VERTEX, "v:some_scalar",  LUTTexture);
   // ここまでは従来と同じ。範囲を固定するために以下を設定する。
  drawable->set_scalar_range( 0., 255.);     // 0-255をLUTTextureの 0-1にマップ
  drawable->set_fixed_scalar_range(true);
```
